### PR TITLE
Update build.gradle to support AGP 8

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -13,6 +13,10 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
+    def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
+    if (agpVersion.tokenize('.')[0].toInteger() >= 7) {
+      namespace "li.yunqi.rnsecurestorage"
+    }
     compileSdkVersion 30
     buildToolsVersion "30.0.0"
 


### PR DESCRIPTION
## Description

Adds Gradle namespace support for multiple libraries, allowing them to be built by apps that are currently using Gradle/AGP 8.x.

Ref: https://developer.android.com/build/releases/past-releases/agp-8-0-0-release-notes#namespace-dsl